### PR TITLE
Add ImportUrl to device drivers to facilitate simpler code upgrades within Hubitat IDE  

### DIFF
--- a/LG_WebOS_TV_Driver.groovy
+++ b/LG_WebOS_TV_Driver.groovy
@@ -35,6 +35,7 @@
  *  Modified to support WebOS SSAP protocol: Cybrmage, 7/18/2019
  *    portions of the websocket code modified from the Logitech Harmony plugin by Dan G Ogorchock 
  *  Refactoring of callbacks, removed hand rolled json: asj, 9/18/2019
+ *  Added ImportURL: Dan G Ogorchock, 12/7/2019
  *
 ***See Release Notes at the bottom***
 ***********************************************************************************************************************/
@@ -45,7 +46,7 @@ import groovy.json.JsonOutput
 import groovy.transform.Field
 
 metadata {
-	definition (name: "LG WebOS TV", namespace: "asj", author: "Andrew Stanley-Jones")
+	definition (name: "LG WebOS TV", namespace: "asj", author: "Andrew Stanley-Jones", importURL: "https://raw.githubusercontent.com/as-j/LG_Smart_TV_hubitat/master/LG_WebOS_TV_Driver.groovy")
 	{
 		capability "Initialize"
 		capability "TV"

--- a/LG_WebOS_TV_Driver.groovy
+++ b/LG_WebOS_TV_Driver.groovy
@@ -46,7 +46,7 @@ import groovy.json.JsonOutput
 import groovy.transform.Field
 
 metadata {
-	definition (name: "LG WebOS TV", namespace: "asj", author: "Andrew Stanley-Jones", importURL: "https://raw.githubusercontent.com/as-j/LG_Smart_TV_hubitat/master/LG_WebOS_TV_Driver.groovy")
+	definition (name: "LG WebOS TV", namespace: "asj", author: "Andrew Stanley-Jones", importUrl: "https://raw.githubusercontent.com/as-j/LG_Smart_TV_hubitat/master/LG_WebOS_TV_Driver.groovy")
 	{
 		capability "Initialize"
 		capability "TV"

--- a/LG_WebOS_TV_Mouse_Driver.groovy
+++ b/LG_WebOS_TV_Mouse_Driver.groovy
@@ -13,6 +13,8 @@
  *  for the specific language governing permissions and limitations under the License.
  *
  *  Original Author: Andrew Stanley-Jones
+ *
+  *  Added ImportURL: Dan G Ogorchock, 12/7/2019
  * 
  */
 
@@ -23,7 +25,7 @@ metadata {
         name: "LG Mouse WebSocket Driver",
         namespace: "asj",
         author: "asj",
-        importUrl: ""
+        importUrl: "https://raw.githubusercontent.com/as-j/LG_Smart_TV_hubitat/master/LG_WebOS_TV_Mouse.driver"
     ) {        
         command "setMouseURI", ["string"]
         command "getURI"


### PR DESCRIPTION
Just a simple addition of the ImportUrl field to the metadata section of the two drivers.  I appreciate your work on this LG TV integration.  Having notifications pop up on my television is a very nice feature.